### PR TITLE
Fix the error message about project name

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ func run(cf *config) error {
 		}
 
 		if len(v.prefixes) == 0 {
-			return fmt.Errorf("Unable to infer project name; specify it explicitly with the '-p' option.")
+			return fmt.Errorf("Unable to infer project name; specify it explicitly with the '-n' option.")
 		}
 	}
 


### PR DESCRIPTION
The error message when not able to find the package name is false, mentionning the `-p` option while it should be the `-n` option.
