### PR TITLE
attempt to guess host if no go meta-tag is exported

### DIFF
--- a/reporoot.go
+++ b/reporoot.go
@@ -105,7 +105,13 @@ func queryRepoRoot(importPath string, security securityMode) (*repoRoot, error) 
 		if err != errNoMatch {
 			return nil, fmt.Errorf("parse %s: %v", urlStr, err)
 		}
-		return nil, fmt.Errorf("parse %s: no go-import meta tags", urlStr)
+
+		bestGuess := strings.Join(strings.Split(importPath, "/")[:3], "/")
+		return &repoRoot{
+			vcs:  "git",
+			repo: fmt.Sprintf("https://%s.git", bestGuess),
+			root: bestGuess,
+		}, nil
 	}
 	if buildV {
 		log.Printf("get %q: found meta tag %#v at %s", importPath, mmi, urlStr)


### PR DESCRIPTION
This tweak makes it so that rather than erroring out if no metadata is provided, it attempts to guess based on convention.

This is especially useful when using something like gitlab which doesn't support go-import meta tags (yet).

The guess assumes git (fair, given vendetta's reliance on submodules) and then uses a 2-directory deep nesting for the root.

eg.

`my.repo.com/my-code/nested/package` becomes

`https://my.repo.com/my-code/nested.git` for the guess.

If the guess is wrong, it will error out later down the line (I think, untested). Works for us and figured I'd see if you wanted it upstream
