### PR TITLE
Include test imports outside of package.

### DIFF
--- a/main.go
+++ b/main.go
@@ -625,6 +625,9 @@ func (v *vendetta) resolveRootProjectDeps(pkgs []rootPackage) error {
 		if err := v.resolveDependencies(pkg.dir, pkg.TestImports); err != nil {
 			return err
 		}
+		if err := v.resolveDependencies(pkg.dir, pkg.XTestImports); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Go allow us to specify external package alongside the current package for testing purpose.

For example, by defining a `books_test` package in `books` folder which allows us to respect the encapsulation of the `books` package. Which is a recommended pattern with [Gingko Testing Framework](https://onsi.github.io/ginkgo/).

This pull request add the support of such practices.
